### PR TITLE
Changed libusb-dev to libusb-1.0-0-dev

### DIFF
--- a/tools/python/README.md
+++ b/tools/python/README.md
@@ -9,10 +9,10 @@ Convert the 24 Ledger words to 25 Electrum/Monero words.
 
 ### Requirements
 
-libusb-dev
+libusb-1.0-0-dev
 libudev-dev
 
-     sudo apt install libusb-dev libudev-dev
+     sudo apt install libusb-1.0-0-dev libudev-dev
 
 The following python package are required:
 


### PR DESCRIPTION
At least on Ubuntu 16.04.5, libusb-dev maps to 1.04 which does not work with ledgerblue python package. 1.0.0 works fine.